### PR TITLE
Show summary before description

### DIFF
--- a/templates/base/route-docs.ejs
+++ b/templates/base/route-docs.ejs
@@ -3,13 +3,13 @@ const { config, route, utils } = it;
 const { _, formatDescription, fmtToJSDocLine, pascalCase, require } = utils;
 const { raw, request, routeName } = route;
 
-const jsDocDescription = raw.description ?
-    ` * @description ${formatDescription(raw.description, true)}` :
-    fmtToJSDocLine('No description', { eol: false });
+const jsDocDescription = _.compact([
+    raw.summary && ` * @summary ${raw.summary}`,
+    raw.description ? ` * @description ${formatDescription(raw.description, true)}` : ''
+]).map(str => str.trimEnd()).join("\n");
 const jsDocLines = _.compact([
     _.size(raw.tags) && ` * @tags ${raw.tags.join(", ")}`,
     ` * @name ${pascalCase(routeName.usage)}`,
-    raw.summary && ` * @summary ${raw.summary}`,
     ` * @request ${_.upperCase(request.method)}:${raw.route}`,
     raw.deprecated && ` * @deprecated`,
     routeName.duplicate && ` * @originalName ${routeName.original}`,


### PR DESCRIPTION
@summary now appears before @description. Also don't show "No description" when the description is not set, instead don't print anything.

An example:

    /**
     * @description Old description *
     * @name oldMethod * @summary Short summary * @request GET:/api/some/path/old */
    oldMethod: (params: RequestParams = {}) =>

    /**
     * @summary Short summary
     * @description New description * * @name newMethod * @request GET:/api/some/path/new */
    newMethod: (params: RequestParams = {}) =>